### PR TITLE
Zion-Core可動に伴う細かいバグ修正

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -48,8 +48,7 @@ export default {
    */
   proxy: {
     '/auth': { target: process.env.CORE_URL, pathRewrite: { '^/auth/': '' } },
-    '/json': { target: process.env.CORE_URL },
-    '/movie': { target: process.env.CORE_URL }
+    '/json': { target: process.env.CORE_URL }
   },
   axios: {
     proxy: true
@@ -110,5 +109,11 @@ export default {
         })
       }
     }
+  },
+  /*
+   ** env
+   */
+  env: {
+    coreUrl: process.env.CORE_URL
   }
 }

--- a/pages/titles/_title/index.vue
+++ b/pages/titles/_title/index.vue
@@ -43,6 +43,9 @@ export default {
   },
   computed: {
     playerOptions() {
+      const movieFileName = `${encodeURIComponent(this.subTitles[this.playedSubTitleNum])}.mp4`
+      const movieFileUrl = `${this.coreUrl}/movie/${this.title}/${movieFileName}?token=${this.jwt}`
+
       return {
         preload: 'auto',
         language: 'ja',
@@ -51,15 +54,13 @@ export default {
         sources: [
           {
             type: 'video/mp4',
-            src: `/movie/${this.title}/${
-              encodeURIComponent(this.subTitles[this.playedSubTitleNum])
-            }.mp4?token=${this.jwt}`
+            src: movieFileUrl
           }
         ]
       }
     }
   },
-  async asyncData({ params, query, app }) {
+  async asyncData({ params, query, app, env }) {
     const subTitles = await app.$axios.$get('/json/getSubtitleArray.php', {
       params: { title: params.title }
     })
@@ -74,7 +75,8 @@ export default {
       playedSubTitleNum,
       subTitles: subTitles.subtitleArray,
       autoPlay: !!query.ap,
-      jwt: app.$cookies.get('jwt_token')
+      jwt: app.$cookies.get('jwt_token'),
+      coreUrl: env.coreUrl
     }
   },
   methods: {

--- a/pages/titles/_title/index.vue
+++ b/pages/titles/_title/index.vue
@@ -52,8 +52,8 @@ export default {
           {
             type: 'video/mp4',
             src: `/movie/${this.title}/${
-              this.subTitles[this.playedSubTitleNum]
-            }`
+              encodeURIComponent(this.subTitles[this.playedSubTitleNum])
+            }.mp4?token=${this.jwt}`
           }
         ]
       }
@@ -73,7 +73,8 @@ export default {
       title: params.title,
       playedSubTitleNum,
       subTitles: subTitles.subtitleArray,
-      autoPlay: !!query.ap
+      autoPlay: !!query.ap,
+      jwt: app.$cookies.get('jwt_token')
     }
   },
   methods: {


### PR DESCRIPTION
# videoタグでの認証が失敗するバグ
cookieに保持していたJWTを動画のURLにクエリパラメータとして付与。
Zion-CoreとZion-Surfaceが異なるドメインで可動したためcookieベースの認証が不可能になった。

# 動画の初期ロードが極端に遅いバグ
ServiceWorkerでのキャッシュ戦略がCacheFirstになっていたためNetWorkFirstに変更。（完全に把握していないがCache無しかもしれない）